### PR TITLE
Ensure reliable SoftAP/DNS startup and add EEPROM SSID fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.pio
+.vscode/
+bin/

--- a/src/128x32_Flexible/nRF24_jammer.cpp
+++ b/src/128x32_Flexible/nRF24_jammer.cpp
@@ -5,6 +5,9 @@
 #include "scan.h"
 #include "serial.h"
 
+static bool webServerStarted = false;
+static bool dnsServerStarted = false;
+
 void handleRoot()
 {
   String main_html = FPSTR(html);
@@ -1321,9 +1324,17 @@ void setup()
     String current_ssid     = getSSIDFromEEPROM();
     String current_password = getPasswordFromEEPROM();
 
-    WiFi.softAP(current_ssid.c_str(), current_password.c_str());
+    WiFi.mode(WIFI_AP);
+    delay(100);
 
-    dnsServer.start(53, "*", WiFi.softAPIP());
+    if ( WiFi.softAP(current_ssid.c_str(), current_password.c_str()) )
+    {
+      IPAddress apIp = WiFi.softAPIP();
+      if ( apIp != IPAddress((uint32_t)0) )
+      {
+        dnsServerStarted = dnsServer.start(53, "*", apIp);
+      }
+    }
 
     registerRoute("/", handleRoot);
     registerRoute("/bluetooth_jam", []() { jamHandler(String("Bluetooth Jamming"), bluetooth_jam, bitmap_bluetooth_jam); });
@@ -1416,6 +1427,7 @@ void setup()
     registerRoute("/set_nrf24_pins", []() { handlernRF24Pins(); });
 
     server.begin();
+    webServerStarted = true;
   }
   Serial.println(logotype + "\n\n");
 
@@ -1484,8 +1496,14 @@ void executeAction(int menuNum)
     display.display();
     while ( nrf24_count <= 0 )
     {
-      server.handleClient();
-      dnsServer.processNextRequest();
+      if ( webServerStarted )
+      {
+        server.handleClient();
+      }
+      if ( dnsServerStarted )
+      {
+        dnsServer.processNextRequest();
+      }
       delay(100);
     }
   }
@@ -1547,8 +1565,14 @@ void loop()
 
   if ( access_point == 0 )
   {
-    server.handleClient();
-    dnsServer.processNextRequest();
+    if ( webServerStarted )
+    {
+      server.handleClient();
+    }
+    if ( dnsServerStarted )
+    {
+      dnsServer.processNextRequest();
+    }
   }
   if ( buttons == 0 )
   {

--- a/src/128x32_Flexible/nRF24_jammer.cpp
+++ b/src/128x32_Flexible/nRF24_jammer.cpp
@@ -465,6 +465,13 @@ void initWiFiSettings()
   {
     saveWiFiSettings(default_ssid, default_password);
   }
+  // If EEPROM contains an empty SSID (zeros), populate defaults so SoftAP can start
+  String ssid = getSSIDFromEEPROM();
+  if ( ssid.length() == 0 )
+  {
+    Serial.println("[DEBUG] EEPROM SSID empty — writing default SSID/password");
+    saveWiFiSettings(default_ssid, default_password);
+  }
 }
 
 String getSSIDFromEEPROM()
@@ -1327,13 +1334,31 @@ void setup()
     WiFi.mode(WIFI_AP);
     delay(100);
 
-    if ( WiFi.softAP(current_ssid.c_str(), current_password.c_str()) )
+    Serial.println("[DEBUG] Starting SoftAP...");
+    Serial.println("[DEBUG] EEPROM SSID: " + current_ssid);
+    Serial.println("[DEBUG] EEPROM PASS: " + current_password);
+    bool softap_ok = WiFi.softAP(current_ssid.c_str(), current_password.c_str());
+    Serial.printf("[DEBUG] WiFi.softAP returned: %d\n", softap_ok);
+    IPAddress apIp = WiFi.softAPIP();
+    Serial.print("[DEBUG] WiFi.softAPIP(): ");
+    Serial.println(apIp);
+    Serial.printf("[DEBUG] WiFi.getMode(): %d\n", WiFi.getMode());
+
+    if ( softap_ok )
     {
-      IPAddress apIp = WiFi.softAPIP();
       if ( apIp != IPAddress((uint32_t)0) )
       {
         dnsServerStarted = dnsServer.start(53, "*", apIp);
+        Serial.printf("[DEBUG] dnsServer.start returned: %d\n", dnsServerStarted);
       }
+      else
+      {
+        Serial.println("[DEBUG] AP IP is 0.0.0.0, not starting DNS");
+      }
+    }
+    else
+    {
+      Serial.println("[DEBUG] WiFi.softAP failed");
     }
 
     registerRoute("/", handleRoot);
@@ -1428,6 +1453,7 @@ void setup()
 
     server.begin();
     webServerStarted = true;
+    Serial.printf("[DEBUG] webServerStarted=%d dnsServerStarted=%d\n", webServerStarted, dnsServerStarted);
   }
   Serial.println(logotype + "\n\n");
 

--- a/src/128x64_Flexible/nRF24_jammer.cpp
+++ b/src/128x64_Flexible/nRF24_jammer.cpp
@@ -5,6 +5,9 @@
 #include "scan.h"
 #include "serial.h"
 
+static bool webServerStarted = false;
+static bool dnsServerStarted = false;
+
 void handleRoot()
 {
   String main_html = FPSTR(html);
@@ -1321,9 +1324,17 @@ void setup()
     String current_ssid     = getSSIDFromEEPROM();
     String current_password = getPasswordFromEEPROM();
 
-    WiFi.softAP(current_ssid.c_str(), current_password.c_str());
+    WiFi.mode(WIFI_AP);
+    delay(100);
 
-    dnsServer.start(53, "*", WiFi.softAPIP());
+    if ( WiFi.softAP(current_ssid.c_str(), current_password.c_str()) )
+    {
+      IPAddress apIp = WiFi.softAPIP();
+      if ( apIp != IPAddress((uint32_t)0) )
+      {
+        dnsServerStarted = dnsServer.start(53, "*", apIp);
+      }
+    }
 
     registerRoute("/", handleRoot);
     registerRoute("/bluetooth_jam", []() { jamHandler(String("Bluetooth Jamming"), bluetooth_jam, bitmap_bluetooth_jam); });
@@ -1416,6 +1427,7 @@ void setup()
     registerRoute("/set_nrf24_pins", []() { handlernRF24Pins(); });
 
     server.begin();
+    webServerStarted = true;
   }
   Serial.println(logotype + "\n\n");
 
@@ -1484,8 +1496,14 @@ void executeAction(int menuNum)
     display.display();
     while ( nrf24_count <= 0 )
     {
-      server.handleClient();
-      dnsServer.processNextRequest();
+      if ( webServerStarted )
+      {
+        server.handleClient();
+      }
+      if ( dnsServerStarted )
+      {
+        dnsServer.processNextRequest();
+      }
       delay(100);
     }
   }
@@ -1547,8 +1565,14 @@ void loop()
 
   if ( access_point == 0 )
   {
-    server.handleClient();
-    dnsServer.processNextRequest();
+    if ( webServerStarted )
+    {
+      server.handleClient();
+    }
+    if ( dnsServerStarted )
+    {
+      dnsServer.processNextRequest();
+    }
   }
   if ( buttons == 0 )
   {

--- a/src/128x64_Flexible/nRF24_jammer.cpp
+++ b/src/128x64_Flexible/nRF24_jammer.cpp
@@ -465,6 +465,13 @@ void initWiFiSettings()
   {
     saveWiFiSettings(default_ssid, default_password);
   }
+  // If EEPROM contains an empty SSID (zeros), populate defaults so SoftAP can start
+  String ssid = getSSIDFromEEPROM();
+  if ( ssid.length() == 0 )
+  {
+    Serial.println("[DEBUG] EEPROM SSID empty — writing default SSID/password");
+    saveWiFiSettings(default_ssid, default_password);
+  }
 }
 
 String getSSIDFromEEPROM()
@@ -1327,13 +1334,31 @@ void setup()
     WiFi.mode(WIFI_AP);
     delay(100);
 
-    if ( WiFi.softAP(current_ssid.c_str(), current_password.c_str()) )
+    Serial.println("[DEBUG] Starting SoftAP...");
+    Serial.println("[DEBUG] EEPROM SSID: " + current_ssid);
+    Serial.println("[DEBUG] EEPROM PASS: " + current_password);
+    bool softap_ok = WiFi.softAP(current_ssid.c_str(), current_password.c_str());
+    Serial.printf("[DEBUG] WiFi.softAP returned: %d\n", softap_ok);
+    IPAddress apIp = WiFi.softAPIP();
+    Serial.print("[DEBUG] WiFi.softAPIP(): ");
+    Serial.println(apIp);
+    Serial.printf("[DEBUG] WiFi.getMode(): %d\n", WiFi.getMode());
+
+    if ( softap_ok )
     {
-      IPAddress apIp = WiFi.softAPIP();
       if ( apIp != IPAddress((uint32_t)0) )
       {
         dnsServerStarted = dnsServer.start(53, "*", apIp);
+        Serial.printf("[DEBUG] dnsServer.start returned: %d\n", dnsServerStarted);
       }
+      else
+      {
+        Serial.println("[DEBUG] AP IP is 0.0.0.0, not starting DNS");
+      }
+    }
+    else
+    {
+      Serial.println("[DEBUG] WiFi.softAP failed");
     }
 
     registerRoute("/", handleRoot);
@@ -1428,6 +1453,7 @@ void setup()
 
     server.begin();
     webServerStarted = true;
+    Serial.printf("[DEBUG] webServerStarted=%d dnsServerStarted=%d\n", webServerStarted, dnsServerStarted);
   }
   Serial.println(logotype + "\n\n");
 


### PR DESCRIPTION

This pull request improves the robustness and reliability of WiFi SoftAP and DNS server initialization and handling (in both variants). The changes add checks to ensure the web and DNS servers are only started and processed when properly initialized avoiding possible boot loops, and enhance debugging output at boot for easier troubleshooting.

**WiFi SoftAP and DNS Server Initialization:**

* Added `webServerStarted` and `dnsServerStarted` flags to track the initialization state of the web server and DNS server, ensuring that requests are only handled when the servers are running.
* Improved SoftAP setup by adding debug output, explicit WiFi mode setting, and checks for successful initialization before starting the DNS server. The DNS server is now only started if the AP IP is valid. [[1]](diffhunk://#diff-3fea21d8d0e820622beaaf72a9cb26d84fd1ce27f9d2be73a1763dcc5f8a22ffL1324-R1362) [[2]](diffhunk://#diff-3fea21d8d0e820622beaaf72a9cb26d84fd1ce27f9d2be73a1763dcc5f8a22ffR1455-R1456)

**EEPROM Handling for WiFi Credentials:**

* Added logic to check if the SSID stored in EEPROM is empty and, if so, write default SSID and password values. This prevents SoftAP startup failures due to missing credentials and avoids the need to use 'set access_point 0' command on first boot.

**Request Processing and Event Loop Updates:**

* Updated `executeAction` and `loop` functions to only call `server.handleClient()` and `dnsServer.processNextRequest()` if the corresponding servers have been successfully started, preventing potential errors. [[1]](diffhunk://#diff-3fea21d8d0e820622beaaf72a9cb26d84fd1ce27f9d2be73a1763dcc5f8a22ffR1524-R1532) [[2]](diffhunk://#diff-3fea21d8d0e820622beaaf72a9cb26d84fd1ce27f9d2be73a1763dcc5f8a22ffR1593-R1602)

**Debugging Enhancements:**

* Added detailed debug print statements throughout the setup process to log WiFi credentials, AP status, IP address, and server initialization results, aiding in troubleshooting. [[1]](diffhunk://#diff-3fea21d8d0e820622beaaf72a9cb26d84fd1ce27f9d2be73a1763dcc5f8a22ffL1324-R1362) [[2]](diffhunk://#diff-3fea21d8d0e820622beaaf72a9cb26d84fd1ce27f9d2be73a1763dcc5f8a22ffR1455-R1456)

**Gitignore**

* Ignored binaries output folder